### PR TITLE
test: Adds a few simulator.js tests

### DIFF
--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -1,0 +1,53 @@
+global.formatAsAddress = require("../headerScript.js").formatAsAddress; //referenced by tokenizer
+
+const simulator = require("../simulator.js");
+
+const clearGlobals = () => {
+
+    global.registers = [new Array(16).fill(0), new Array(16).fill(0)];
+    global.PC = 0;
+    global.machineCode = [new Array(4096).fill({hex: '00000', line: 0})];
+    global.regbank = 0;
+    global.flagZ = [0,0];
+    global.flagC = [0,0];
+
+    global.breakpoints = [];
+    global.playing = false;
+    global.displayRegistersAndFlags = jest.fn();
+    global.alert = (...args) => console.log(args);
+
+    for (let i = 0; i < 10; i++){
+        const td = document.createElement('td');
+        td.setAttribute('id', "PC_label_" + formatAsAddress(i));
+        document.body.appendChild(td);
+    }
+};
+
+describe("PicoBlaze MachineCode Simulator", () => {
+    beforeEach(clearGlobals)
+
+    test("add 4 + 5 equals 9", () => {
+        global.machineCode = [
+            {hex: '01005', line: 3}, //load s0, 5
+            {hex: '11004', line: 4}, //add s0, 4
+        ];
+
+
+        simulator.simulateOneInstruction(); //load s0, 5
+        simulator.simulateOneInstruction(); //add s0, 4
+        expect(registers[0][0]).toBe(9);
+    })
+
+    test("SR1 shifts right adding 1", () => {
+        global.machineCode = [
+            {hex: '01005', line: 3}, //load s0, 00000101´b
+            {hex: '1400f', line: 4}, //sr1 s0
+        ];
+
+
+        simulator.simulateOneInstruction(); //load s0, 00000101´b
+        simulator.simulateOneInstruction(); //sr1 s0
+        expect(registers[0][0].toString(2)).toBe('10000010');
+    })
+
+})


### PR DESCRIPTION
Hey again! 

Added a few example tests to simulator.js

Tried not to touch any existing code before I could understand it and cover it with a test. Mostly so that we make sure we aren't breaking anything by refactoring.

It's been a challenge to test global state (and also very brittle).

One thing we could do to fix this is to make `simulateOneInstruction` a pure function by extracting the global state to an argument and simply pass it in every call. Then we could simply delete that smelly beforeEach.

**Example:**
```
function simulateOneInstruction(state) {
    const {flagZ, flagC, machineCode, etc} = state;
   //rest of the function as normal
}
```

### Next steps?

Another few ideas we could do to make it more testable (and portable!) is to extract everything related to the DOM from the function and keep the presentation layer (the DOM) from the actual code. This would become handy once you try to port it to another platform such as Android as you could simply copy the code almost line by line and instead only change the view. (or use it as a library in node!) If you don't mind I'll try making an example of what I mean tomorrow.

Also we could probably move everything related to the simulator driver outside the scope of the function. Basically keep the function doing one thing and doing it well. Which is to be the transformation function of state0 -> state1. The driver would be the one which would keep the state of the breakpoints, the playing variable, and of moving through each instruction.
