### PR TITLE
test: add a few more simulator tests

### DIFF
--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -50,4 +50,32 @@ describe("PicoBlaze MachineCode Simulator", () => {
         expect(registers[0][0].toString(2)).toBe('10000010');
     })
 
+    test("sub 5 - 4 equals 1", () => {
+        global.machineCode = [{hex:"01005",line:3},{hex:"19004",line:4}]
+        console.time("test")
+        simulator.simulateOneInstruction(); //load s0, 0
+        simulator.simulateOneInstruction(); //sub s4, 4
+
+        expect(registers[0][0]).toBe(1);
+    })
+
+    test("jump nz + labels work", () => {
+        global.machineCode = [{hex:"01000",line:4},{hex:"011ff",line:5},{hex:"11001",line:7},{hex:"19101",line:8},
+            {hex:"36002",line:9}]
+        simulator.simulateOneInstruction(); //load s0, 0
+        simulator.simulateOneInstruction(); //load s1, 255'd
+
+        /*
+        label:
+        add s0, 1
+        sub s1, 1
+        jump nz, label
+         */
+        for (let i = 0; i < 255 * 3; i++) {
+            //we do it a few times since it's fast :). took less than 100ms on my machine
+            simulator.simulateOneInstruction();
+        }
+        expect(registers[0][0]).toBe(255);
+    })
+
 })


### PR DESCRIPTION
Hey, I've went ahead and added a few more simulator tests before I commit to refactoring. Just to make sure I don't accidentally break anything.

Something of note is that as you can probably see from the jump nz test the simulator speed is just fine. It loops in less than 100ms on my machine.

The issue with the web version is likely that it's limited by setInterval(sim, 0) in footer.js. Browsers usually throttle the intervals to at least 4ms per tick.