### PR TITLE
test: Add Uart output test

### DIFF
--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -21,6 +21,13 @@ const clearGlobals = () => {
         td.setAttribute('id', "PC_label_" + formatAsAddress(i));
         document.body.appendChild(td);
     }
+
+    /* UART setup*/
+    global.is_UART_enabled = false;
+    const uartOutputEl = document.createElement('pre');
+    uartOutputEl.setAttribute('id', 'UART_OUTPUT');
+    uartOutputEl.innerText = "";
+    document.body.appendChild(uartOutputEl);
 };
 
 describe("PicoBlaze MachineCode Simulator", () => {
@@ -76,6 +83,26 @@ describe("PicoBlaze MachineCode Simulator", () => {
             simulator.simulateOneInstruction();
         }
         expect(registers[0][0]).toBe(255);
+    })
+
+    test("Output register to UART terminal", () => {
+        global.is_UART_enabled = true;
+
+        const machineCode = 'Hello'.split('')
+            .map((c, i) => [
+                //Convert every char to its codepoint and load s0
+                {hex: '010' + c.charCodeAt(0).toString(16), line: i*2+1},
+                //Write to port 3
+                {hex: '2d003', line: i*2+2}
+            ])
+            .flat();
+
+        global.machineCode = machineCode;
+        machineCode.forEach(() => {
+            simulator.simulateOneInstruction();
+        })
+
+        expect(document.getElementById("UART_OUTPUT").innerText).toBe('Hello')
     })
 
 })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A PicoBlaze simulator in JS",
   "main": "app.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --verbose"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Couldn't help myself to add a UART Output test before heading off to work.

I still want to add a UART input test before I start to refactor out the global state as those two branches are the only that touch the DOM directly and depend on a few globals.

Also added the --verbose option to jest so that we can see every tests result with timings on the github actions console.