### PR TITLE
feat: refactored out globals

### DIFF
--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -45,8 +45,8 @@ describe("PicoBlaze MachineCode Simulator", () => {
         ];
 
 
-        simulator.simulateOneInstruction(); //load s0, 5
-        simulator.simulateOneInstruction(); //add s0, 4
+        simulator.simulateOneInstructionUsingGlobals(); //load s0, 5
+        simulator.simulateOneInstructionUsingGlobals(); //add s0, 4
         expect(registers[0][0]).toBe(9);
     })
 
@@ -57,16 +57,16 @@ describe("PicoBlaze MachineCode Simulator", () => {
         ];
 
 
-        simulator.simulateOneInstruction(); //load s0, 00000101´b
-        simulator.simulateOneInstruction(); //sr1 s0
+        simulator.simulateOneInstructionUsingGlobals(); //load s0, 00000101´b
+        simulator.simulateOneInstructionUsingGlobals(); //sr1 s0
         expect(registers[0][0].toString(2)).toBe('10000010');
     })
 
     test("sub 5 - 4 equals 1", () => {
         global.machineCode = [{hex:"01005",line:3},{hex:"19004",line:4}]
         console.time("test")
-        simulator.simulateOneInstruction(); //load s0, 0
-        simulator.simulateOneInstruction(); //sub s4, 4
+        simulator.simulateOneInstructionUsingGlobals(); //load s0, 0
+        simulator.simulateOneInstructionUsingGlobals(); //sub s4, 4
 
         expect(registers[0][0]).toBe(1);
     })
@@ -74,8 +74,8 @@ describe("PicoBlaze MachineCode Simulator", () => {
     test("jump nz + labels work", () => {
         global.machineCode = [{hex:"01000",line:4},{hex:"011ff",line:5},{hex:"11001",line:7},{hex:"19101",line:8},
             {hex:"36002",line:9}]
-        simulator.simulateOneInstruction(); //load s0, 0
-        simulator.simulateOneInstruction(); //load s1, 255'd
+        simulator.simulateOneInstructionUsingGlobals(); //load s0, 0
+        simulator.simulateOneInstructionUsingGlobals(); //load s1, 255'd
 
         /*
         label:
@@ -85,7 +85,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
          */
         for (let i = 0; i < 255 * 3; i++) {
             //we do it a few times since it's fast :). took less than 100ms on my machine
-            simulator.simulateOneInstruction();
+            simulator.simulateOneInstructionUsingGlobals();
         }
         expect(registers[0][0]).toBe(255);
     })
@@ -105,7 +105,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
             );
 
         global.machineCode.forEach(() => {
-            simulator.simulateOneInstruction();
+            simulator.simulateOneInstructionUsingGlobals();
         })
 
         //Reconstruct string from registers
@@ -132,7 +132,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
 
         global.machineCode = machineCode;
         machineCode.forEach(() => {
-            simulator.simulateOneInstruction();
+            simulator.simulateOneInstructionUsingGlobals();
         })
 
         expect(document.getElementById("UART_OUTPUT").innerText).toBe('Hello')

--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -2,17 +2,23 @@ global.formatAsAddress = require("../headerScript.js").formatAsAddress; //refere
 
 const simulator = require("../simulator.js");
 
+function initialState() {
+    return {
+        registers: [new Array(16).fill(0), new Array(16).fill(0)],
+        PC: 0,
+        machineCode: [new Array(4096).fill({hex: '00000', line: 0})],
+        regbank: 0,
+        flagZ: [0, 0],
+        flagC: [0, 0],
+        breakpoints: [],
+        playing: false
+    }
+}
+
 const clearGlobals = () => {
 
-    global.registers = [new Array(16).fill(0), new Array(16).fill(0)];
-    global.PC = 0;
-    global.machineCode = [new Array(4096).fill({hex: '00000', line: 0})];
-    global.regbank = 0;
-    global.flagZ = [0,0];
-    global.flagC = [0,0];
+    Object.assign(global, initialState())
 
-    global.breakpoints = [];
-    global.playing = false;
     global.displayRegistersAndFlags = jest.fn();
     global.alert = (...args) => console.log(args);
 
@@ -48,6 +54,21 @@ describe("PicoBlaze MachineCode Simulator", () => {
         simulator.simulateOneInstruction(); //load s0, 5
         simulator.simulateOneInstruction(); //add s0, 4
         expect(registers[0][0]).toBe(9);
+    })
+
+    test("add 4 + 5 equals 9 using state", () => {
+        const machineCode = [
+            {hex: '01005', line: 3}, //load s0, 5
+            {hex: '11004', line: 4}, //add s0, 4
+        ];
+
+        const state = {...initialState(), machineCode};
+
+        simulator.simulateOneInstruction(state); //load s0, 5
+        simulator.simulateOneInstruction(state); //add s0, 4
+
+        expect(state.registers[0][0]).toBe(9);
+        expect(state.PC).toBe(2)
     })
 
     test("SR1 shifts right adding 1", () => {

--- a/__tests__/simulator.test.js
+++ b/__tests__/simulator.test.js
@@ -16,7 +16,7 @@ const clearGlobals = () => {
     global.displayRegistersAndFlags = jest.fn();
     global.alert = (...args) => console.log(args);
 
-    for (let i = 0; i < 10; i++){
+    for (let i = 0; i < 30; i++){
         const td = document.createElement('td');
         td.setAttribute('id', "PC_label_" + formatAsAddress(i));
         document.body.appendChild(td);
@@ -45,8 +45,8 @@ describe("PicoBlaze MachineCode Simulator", () => {
         ];
 
 
-        simulator.simulateOneInstructionUsingGlobals(); //load s0, 5
-        simulator.simulateOneInstructionUsingGlobals(); //add s0, 4
+        simulator.simulateOneInstruction(); //load s0, 5
+        simulator.simulateOneInstruction(); //add s0, 4
         expect(registers[0][0]).toBe(9);
     })
 
@@ -57,16 +57,16 @@ describe("PicoBlaze MachineCode Simulator", () => {
         ];
 
 
-        simulator.simulateOneInstructionUsingGlobals(); //load s0, 00000101´b
-        simulator.simulateOneInstructionUsingGlobals(); //sr1 s0
+        simulator.simulateOneInstruction(); //load s0, 00000101´b
+        simulator.simulateOneInstruction(); //sr1 s0
         expect(registers[0][0].toString(2)).toBe('10000010');
     })
 
     test("sub 5 - 4 equals 1", () => {
         global.machineCode = [{hex:"01005",line:3},{hex:"19004",line:4}]
         console.time("test")
-        simulator.simulateOneInstructionUsingGlobals(); //load s0, 0
-        simulator.simulateOneInstructionUsingGlobals(); //sub s4, 4
+        simulator.simulateOneInstruction(); //load s0, 0
+        simulator.simulateOneInstruction(); //sub s4, 4
 
         expect(registers[0][0]).toBe(1);
     })
@@ -74,8 +74,8 @@ describe("PicoBlaze MachineCode Simulator", () => {
     test("jump nz + labels work", () => {
         global.machineCode = [{hex:"01000",line:4},{hex:"011ff",line:5},{hex:"11001",line:7},{hex:"19101",line:8},
             {hex:"36002",line:9}]
-        simulator.simulateOneInstructionUsingGlobals(); //load s0, 0
-        simulator.simulateOneInstructionUsingGlobals(); //load s1, 255'd
+        simulator.simulateOneInstruction(); //load s0, 0
+        simulator.simulateOneInstruction(); //load s1, 255'd
 
         /*
         label:
@@ -85,7 +85,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
          */
         for (let i = 0; i < 255 * 3; i++) {
             //we do it a few times since it's fast :). took less than 100ms on my machine
-            simulator.simulateOneInstructionUsingGlobals();
+            simulator.simulateOneInstruction();
         }
         expect(registers[0][0]).toBe(255);
     })
@@ -105,7 +105,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
             );
 
         global.machineCode.forEach(() => {
-            simulator.simulateOneInstructionUsingGlobals();
+            simulator.simulateOneInstruction();
         })
 
         //Reconstruct string from registers
@@ -132,7 +132,7 @@ describe("PicoBlaze MachineCode Simulator", () => {
 
         global.machineCode = machineCode;
         machineCode.forEach(() => {
-            simulator.simulateOneInstructionUsingGlobals();
+            simulator.simulateOneInstruction();
         })
 
         expect(document.getElementById("UART_OUTPUT").innerText).toBe('Hello')

--- a/simulator.js
+++ b/simulator.js
@@ -1,25 +1,28 @@
 "use strict";
-function simulateOneInstructionUsingGlobals() {
-  const state = {
-    machineCode,
-    registers,
-    PC,
-    regbank,
-    flagZ,
-    flagC,
-    breakpoints,
-    playing,
-    displayRegistersAndFlags: ()=>{},
-    alert: console.log
-  }
-
-  simulateOneInstruction(state);
-  Object.assign(window, state);
-}
 
 function simulateOneInstruction(state) {
+
+  //Temporary overload
+  if (state == null) {
+    // Create state from globals, call itself with a state made from globals, assign again then return
+    // This is so existing code can keep working as it did. Once everything is refactored out state should be mandatory
+    const state = {
+      machineCode: window.machineCode,
+      registers: window.registers,
+      PC: window.PC, //int primitive (must reassign to state after simulateOneInstruction)
+      regbank: window.regbank, //int primitive (same)
+      flagZ: window.flagZ,
+      flagC: window.flagC,
+      breakpoints: window.breakpoints,
+      playing: window.playing,
+    }
+    simulateOneInstruction(state);
+    Object.assign(window, state); //Reassign mutated state to the globals and return
+    return;
+  }
+  let {machineCode, flagC, flagZ, registers, regbank, playing, PC} = state;
   try {
-    let PC = state.PC % 4096; // If you are at the end of a program, and there is no "return"
+    PC = PC % 4096; // If you are at the end of a program, and there is no "return"
     // there, jump to the beginning of the program. I think that's
     // how PicoBlaze behaves, though I haven't tried it.
     if (breakpoints.includes(machineCode[PC].line)) {
@@ -922,7 +925,6 @@ function simulateOneInstruction(state) {
           machineCode[PC].line + ".");
       stopSimulation();
     }
-    state.PC = PC;
     displayRegistersAndFlags();
     document.getElementById("PC_label_" + formatAsAddress(PC)).innerHTML =
         "-&gt;";
@@ -931,4 +933,7 @@ function simulateOneInstruction(state) {
       clearInterval(simulationThread);
     alert("The simulator crashed! Error: " + error.message);
   }
+  state.playing = playing;
+  state.PC = PC;
+  state.regbank = regbank;
 }

--- a/simulator.js
+++ b/simulator.js
@@ -13,14 +13,34 @@ function simulateOneInstruction(state) {
       regbank: window.regbank, //int primitive (same)
       flagZ: window.flagZ,
       flagC: window.flagC,
+      flagIE: window.flagIE, //int primitive
       breakpoints: window.breakpoints,
-      playing: window.playing,
+      playing: window.playing, //boolean primitive
+      memory: window.memory,
+      callStack: window.callStack,
+      is_UART_enabled: window.is_UART_enabled, //readonly boolean primitive
+      currentlyReadCharacterInUART: window.currentlyReadCharacterInUART //int primitive
     }
     simulateOneInstruction(state);
     Object.assign(window, state); //Reassign mutated state to the globals and return
     return;
   }
-  let {machineCode, flagC, flagZ, registers, regbank, playing, PC} = state;
+  let {
+    machineCode,
+    PC,
+    registers,
+    flagC,
+    flagZ,
+    flagIE,
+    regbank,
+    playing,
+    breakpoints,
+    memory,
+    callStack,
+    is_UART_enabled,
+    currentlyReadCharacterInUART
+  } = state;
+
   try {
     PC = PC % 4096; // If you are at the end of a program, and there is no "return"
     // there, jump to the beginning of the program. I think that's
@@ -933,7 +953,12 @@ function simulateOneInstruction(state) {
       clearInterval(simulationThread);
     alert("The simulator crashed! Error: " + error.message);
   }
-  state.playing = playing;
+
+  // reassigned here, we could also mutate state in place
   state.PC = PC;
   state.regbank = regbank;
+  state.flagIE = flagIE;
+  state.playing = playing;
+  state.is_UART_enabled = is_UART_enabled; //This one is readonly, no need to reassign here
+  state.currentlyReadCharacterInUART = currentlyReadCharacterInUART;
 }

--- a/simulator.js
+++ b/simulator.js
@@ -1,8 +1,25 @@
 "use strict";
-function simulateOneInstruction() {
+function simulateOneInstructionUsingGlobals() {
+  const state = {
+    machineCode,
+    registers,
+    PC,
+    regbank,
+    flagZ,
+    flagC,
+    breakpoints,
+    playing,
+    displayRegistersAndFlags: ()=>{},
+    alert: console.log
+  }
+
+  simulateOneInstruction(state);
+  Object.assign(window, state);
+}
+
+function simulateOneInstruction(state) {
   try {
-    PC = PC %
-         4096; // If you are at the end of a program, and there is no "return"
+    let PC = state.PC % 4096; // If you are at the end of a program, and there is no "return"
     // there, jump to the beginning of the program. I think that's
     // how PicoBlaze behaves, though I haven't tried it.
     if (breakpoints.includes(machineCode[PC].line)) {
@@ -905,6 +922,7 @@ function simulateOneInstruction() {
           machineCode[PC].line + ".");
       stopSimulation();
     }
+    state.PC = PC;
     displayRegistersAndFlags();
     document.getElementById("PC_label_" + formatAsAddress(PC)).innerHTML =
         "-&gt;";

--- a/simulator.js
+++ b/simulator.js
@@ -18,6 +18,7 @@ function simulateOneInstruction(state) {
       playing: window.playing, //boolean primitive
       memory: window.memory,
       callStack: window.callStack,
+      output: window.output,
       is_UART_enabled: window.is_UART_enabled, //readonly boolean primitive
       currentlyReadCharacterInUART: window.currentlyReadCharacterInUART //int primitive
     }
@@ -37,6 +38,7 @@ function simulateOneInstruction(state) {
     breakpoints,
     memory,
     callStack,
+    output,
     is_UART_enabled,
     currentlyReadCharacterInUART
   } = state;


### PR DESCRIPTION
POC showing extracted globals. See the add test in simulator.test.js.

It's not really ready yet, only moved around the globals but they could probably be made a bit more ergonomic and easier to work with. (maybe returning a new state for example)

Also the rest of the codebase (footer.js) still assumes those globals, iI still have to modify that a bit to make it work and delete the first lines of code in simulateOneStep().