### PR TITLE
Potential fix for code scanning alert no. 4: Dangerous use of 'cin'

### DIFF
--- a/bin2dec.cpp
+++ b/bin2dec.cpp
@@ -26,6 +26,7 @@ volatile uint64_t first_digit, Gray_code,
 
 int main() {
   std::cout << "Enter a binary number containing at most 8 digits: ";
+  std::cin.width(9);
   std::cin >> binary_input;
   asm(R"assembly(
         .intel_syntax noprefix


### PR DESCRIPTION
Potential fix for [https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS/security/code-scanning/4](https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS/security/code-scanning/4)

To fix the problem, we should set the width of the input stream before reading into `binary_input`. Because `binary_input` is 9 bytes, and the code expects “at most 8 digits”, we should read at most 8 bytes into the buffer (leaving space for the null terminator). The best fix is to insert `std::cin.width(9);` (or `.width(sizeof(binary_input));`) before the input operation so as to guarantee that at most 8 non-null characters and a null terminator are written. The only required change is to insert `std::cin.width(9);` just before `std::cin >> binary_input;` in bin2dec.cpp.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
