### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/viewer.js
+++ b/viewer.js
@@ -45,9 +45,22 @@ document.addEventListener("DOMContentLoaded", function() {
         })
 
         .catch((error) => {
+          // Escape user-supplied ID to prevent XSS
+          function escapeHtml(str) {
+            return str.replace(/[&<>"'`]/g, function (s) {
+              return ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+                '`': '&#96;'
+              })[s];
+            });
+          }
           document.getElementById("assemblyCode").innerHTML =
               `;Unfortunately, fetching the example
-;program "${id}" from SourceForge failed.
+;program "${escapeHtml(id)}" from SourceForge failed.
 ;No worries, you can still select one of
 ;the example programs to fetch from
 ;GitHub.


### PR DESCRIPTION
Potential fix for [https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS/security/code-scanning/3](https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS/security/code-scanning/3)

To fix the DOM-based XSS, we must prevent untrusted data (`id`) from being interpreted as HTML by the browser when assigning it to the DOM. The safest method is to encode or escape the user input so that even if it contains HTML or script, it will only appear as plain text, not executed code. In this context, since the string is meant to resemble assembly code or plain text, we should HTML-escape the variable, ensuring all output is inert. The fix involves creating a small utility function to escape HTML special characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) and using this function to sanitize `id` before embedding it in the template. This change is to be made in `viewer.js` at the assignment to `innerHTML` in the catch handler (line 49/50).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
